### PR TITLE
Export headers module to enable matching on ProcTypeType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 extern crate nom;
 
 mod parsers;
-mod headers;
+pub mod headers;
 mod display;
 
 use std::str;


### PR DESCRIPTION
Not sure if this is the right/intended API but I wanted to detect presence/absence of the ENCRYPTED type. I exposed the headers module and implemented this.

```rust
extern crate nom_pem;
use nom_pem::headers::{HeaderEntry, ProcTypeType};

fn is_encrypted(headers: &Vec<HeaderEntry>) -> bool {
    headers
        .iter()
        .any(|header| match header {
                 &HeaderEntry::ProcType(_code, ref kind) => kind == &ProcTypeType::ENCRYPTED,
                 _ => false,
             })
}
```